### PR TITLE
게시글 Hotfix 파일 권한 관련 수정

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -27,18 +27,25 @@
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
-			<attribute name="org.eclipse.jst.component.dependency" value="/WEB-INF/lib"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
-	<classpathentry kind="src" path="target/generated-sources/annotations">
-		<attributes>
-			<attribute name="optional" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resource-${env}">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
 			<attribute name="optional" value="true"/>
 		</attributes>
 	</classpathentry>

--- a/src/main/java/com/portfolio/www/forum/board/util/FileUtil.java
+++ b/src/main/java/com/portfolio/www/forum/board/util/FileUtil.java
@@ -56,6 +56,7 @@ public class FileUtil {
 		
 		try {
 			mpf.transferTo(destFile);
+			destFile.setReadable(true,false);
 		} catch (IllegalStateException ise) {	
 			CommonUtil.getLogMessage(log, "saveFile", "IllegalStateException", ise.getMessage());
 			throw ise;


### PR DESCRIPTION
### 구현 페이지
📦2024_Portfolio
 ┣ 📂.git
 ┣ 📂.settings
 ┣ 📂build
 ┣ 📂src
 ┃ ┣ 📂main
 ┃ ┃ ┣ 📂java
 ┃ ┃ ┃ ┗ 📂com
 ┃ ┃ ┃ ┃ ┗ 📂portfolio
 ┃ ┃ ┃ ┃ ┃ ┗ 📂www
 ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂common
 ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂forum
 ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📂board
 ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂controller
 ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂dao
 ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂exception
 ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂message
 ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂service
 ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📂util
 ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📜FileUtil.java
 ┃ ┃ ┃ ┃ ┃ ┃ ┣ 📂index
 ┃ ┃ ┃ ┃ ┃ ┃ ┗ 📂user
 ┃ ┃ ┣ 📂resource-common
 ┃ ┗ 📂test
┗📂WebContent
 

### 추가 구현
- [inotify-tools](https://docs.rockylinux.org/books/learning_rsync/06_rsync_inotify/) 사용해봄.. 
    (해결은 간단히 됬지만 모니터링,chmod 를 위해서 해당 라이브러리 사용해봄)

### 트러블 슈팅 
- 

### 추가 개발 예정 
- 로그인, 게시글 리팩토링
- 로그인필터 부분 수정


---
 ## 이슈
  - [x]  첨부파일 ec2 서버에 올라가 있는 이미지 권한 설정 후 이미지 데이터 미리보기 처리하기

## 기능 요구 사항(밑줄은 test pass)
- 게시물 조회
    - 페이징 현재 1페이지씩 화살표 넘어가는데 10개씩 넘어가는건 ? 구현 ?
    - [x]  page 왼쪽 마지막인 경우 page 10 → 1 로 되서 제일 첫번째(최신기준) 뜨게 하기(맨 처음, 맨끝 처리)
      <img width ="700" height= "60" src = "https://github.com/InitTester/2024_Portfolio/assets/143479869/f433d557-82f0-460d-9ac4-a3d17151b6c7">    
    - [x]  페이징 size 강제 입력 할때 적용 안되게 처리하기
    - [x]  size에 따른 네비게이션수 수정
      <img width ="500" height= "120" src = "https://github.com/InitTester/2024_Portfolio/assets/143479869/f9f38210-ef65-4296-af19-4eec5025e9e3">        
- 게시물 등록
- 게시물 상세조회
    - [x]  좋아요/싫어요 버튼 두번 누루면 취소 안되는 현상
    ~~- []  대댓글 2래밸 이상은 같은 위치에서 멘션으로 처리 위치 (아래와 같은 느낌)
      <img width ="200" height= "400" src = "https://github.com/InitTester/2024_Portfolio/assets/143479869/2e8ea15d-f8e9-4efc-93b4-83549d8e6291"> <삭제>~~             
    - [x]  무한댓글로 변경
- 게시글 수정
    - [x]  첨부파일 ec2 서버에 올라가 있는 이미지 권한 설정 후 이미지 데이터 미리보기 처리하기
    - [x] 아래 중 2번으로 처리, 수정도 같이 적용
     ~~1.  기존 첨부파일 지우고 추가/기존 데이터값으로 첨부파일을 올릴 것인가?~~
      2. 기존 첨부파일 제외 하고 신규 추가된 값만 저장할 것인가 ?     
    - [x]  첨부파일 추가 이후 에러 (http://localhost:8080/pf/forum/board/edit.do)
    Exception (Request processing failed; nested exception is org.mybatis.spring.MyBatisSystemException: nested exception is org.apache.ibatis.reflection.ReflectionException: There is no getter for property named 'org_file_nm' in 'class com.portfolio.www.forum.board.dto.BoardAttachDto')
      <img width ="200" height= "400" src = "https://github.com/InitTester/2024_Portfolio/assets/143479869/10a9af99-ff9b-4f45-b59b-2fda9afcf329">       
- 게시글 삭제
    - [x]  삭제 버튼 클릭 이후 에러(http://localhost:8080/pf/forum/board/listPage.do)
      [LogFilter] Exception (null)